### PR TITLE
Exclude newlines from whitespace either side of =

### DIFF
--- a/lib/File/DesktopEntry.pm
+++ b/lib/File/DesktopEntry.pm
@@ -465,7 +465,7 @@ sub get {
 	return undef unless defined $i;
 	my $lang = join('|', map quotemeta($_), @lang) || 'C';
 	my %matches = ( $$self{groups}[$i] =~
-		/^(\Q$key\E\[(?:$lang)\]|\Q$key\E)\s*=\s*(.*?)\s*$/gm );
+		/^(\Q$key\E\[(?:$lang)\]|\Q$key\E)[^\S\n]*=[^\S\n]*(.*?)\s*$/gm );
 	return undef unless keys %matches;
 
 	# Find preferred value


### PR DESCRIPTION
\s includes \n so the key pattern using multiline matching can eat successive lines, use [^\S\n] instead.

Fixes https://rt.cpan.org/Public/Bug/Display.html?id=65394